### PR TITLE
⚡ Bolt: Optimize Math.max and Math.min with reduce

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-XX-XX - Avoid spreading mapped arrays into Math.max/min
+**Learning:** Using `Math.max(...arr.map(x => x.y))` can cause 'Maximum call stack size exceeded' on large arrays and creates unnecessary intermediate array allocations, reducing performance.
+**Action:** Use a single `.reduce()` pass to calculate min/max values efficiently without intermediate array creation.

--- a/src/components/MetabolismChart.jsx
+++ b/src/components/MetabolismChart.jsx
@@ -34,8 +34,9 @@ const MetabolismChart = ({
   // 计算y轴最大值
   const yMax = useMemo(() => {
     // 找出图表数据中的最大咖啡因量
+    // Bolt: 优化性能，避免中间数组分配和扩展运算符带来的潜在栈溢出风险
     const maxCaffeineValue = metabolismChartData.length > 0
-      ? Math.max(...metabolismChartData.map(d => d.caffeine))
+      ? metabolismChartData.reduce((max, d) => Math.max(max, d.caffeine), -Infinity)
       : 50; // 如果没有数据，默认为50
 
     // 取最大咖啡因量和安全睡眠量中的较大值，并向上取整到10的倍数

--- a/src/components/StatsChart.jsx
+++ b/src/components/StatsChart.jsx
@@ -47,7 +47,8 @@ const StatsChart = ({
   if (view === 'year') title = '每月摄入量 (mg)';
 
   // 找出数据中的最大值
-  const maxValue = Math.max(...data.map(d => d.value));
+  // Bolt: 优化性能，避免使用 ...map 带来的中间数组创建和调用栈溢出风险
+  const maxValue = data.reduce((max, d) => Math.max(max, d.value), -Infinity);
 
   // 根据视图类型确定Y轴最大值
   let yMax;

--- a/src/views/CurrentStatusView.jsx
+++ b/src/views/CurrentStatusView.jsx
@@ -369,10 +369,11 @@ const CurrentStatusView = ({
       record.timestamp >= dayStartTime && record.timestamp <= dayEndTime
     );
 
+    // Bolt: 优化性能，避免使用 ...map 带来的中间数组创建和调用栈溢出风险
     const firstIntake = todayRecords.length > 0 ?
-      formatTime(Math.max(...todayRecords.map(r => r.timestamp))) : null;
+      formatTime(todayRecords.reduce((max, r) => Math.max(max, r.timestamp), -Infinity)) : null;
     const lastIntake = todayRecords.length > 0 ?
-      formatTime(Math.min(...todayRecords.map(r => r.timestamp))) : null;
+      formatTime(todayRecords.reduce((min, r) => Math.min(min, r.timestamp), Infinity)) : null;
 
     return {
       recordCount: todayRecords.length,

--- a/src/views/StatisticsView.jsx
+++ b/src/views/StatisticsView.jsx
@@ -340,7 +340,8 @@ const StatisticsView = ({
     });
 
     // 找出高峰时段
-    const peakHour = hourlyDistribution.indexOf(Math.max(...hourlyDistribution));
+    // Bolt: 优化性能，避免使用 ... 带来的中间数组创建和调用栈溢出风险
+    const peakHour = hourlyDistribution.indexOf(hourlyDistribution.reduce((max, val) => Math.max(max, val), -Infinity));
     const peakAmount = hourlyDistribution[peakHour];
 
     // 计算摄入间隔
@@ -353,7 +354,8 @@ const StatisticsView = ({
     const avgInterval = intervals.length > 0 ? intervals.reduce((a, b) => a + b) / intervals.length : 0;
 
     // 最大单次摄入
-    const maxSingleIntake = Math.max(...records.map(r => r.amount));
+    // Bolt: 优化性能，避免使用 ...map 带来的中间数组创建和调用栈溢出风险
+    const maxSingleIntake = records.reduce((max, r) => Math.max(max, r.amount), -Infinity);
 
     // 1. 获取所有记录的日期，确保它们是当天的开始时间，并去重
     const uniqueDayTimestampsForStreak = [...new Set(
@@ -404,7 +406,8 @@ const StatisticsView = ({
       const weekday = new Date(record.timestamp).getDay();
       weekdayTotals[weekday] += record.amount;
     });
-    const maxWeekdayIndex = weekdayTotals.indexOf(Math.max(...weekdayTotals));
+    // Bolt: 优化性能，避免使用 ... 带来的中间数组创建和调用栈溢出风险
+    const maxWeekdayIndex = weekdayTotals.indexOf(weekdayTotals.reduce((max, val) => Math.max(max, val), -Infinity));
     const weekdayNames = ['周日', '周一', '周二', '周三', '周四', '周五', '周六'];
 
     const totalAmount = records.reduce((sum, r) => sum + r.amount, 0);
@@ -568,8 +571,9 @@ const StatisticsView = ({
     const values = statsChartData.map(d => d.value);
     const nonZeroValues = values.filter(v => v > 0);
 
-    const maxDay = Math.max(...values);
-    const minDay = nonZeroValues.length > 0 ? Math.min(...nonZeroValues) : 0;
+    // Bolt: 优化性能，避免使用 ... 带来的中间数组创建和调用栈溢出风险
+    const maxDay = values.reduce((max, val) => Math.max(max, val), -Infinity);
+    const minDay = nonZeroValues.length > 0 ? nonZeroValues.reduce((min, val) => Math.min(min, val), Infinity) : 0;
     const avgDay = nonZeroValues.length > 0 ? nonZeroValues.reduce((a, b) => a + b) / nonZeroValues.length : 0;
     const activeDays = nonZeroValues.length;
 
@@ -1183,7 +1187,8 @@ const StatisticsView = ({
                   // onClick handler removed from here, handled by parent div
                   >
                     {detailedStats.weekdayTotals.map((amount, index) => {
-                      const maxAmount = Math.max(...detailedStats.weekdayTotals);
+                      // Bolt: 优化性能，避免使用 ... 带来的中间数组创建和调用栈溢出风险
+                      const maxAmount = detailedStats.weekdayTotals.reduce((max, val) => Math.max(max, val), -Infinity);
                       const percentage = maxAmount > 0 ? (amount / maxAmount) * 100 : 0;
                       const isMax = index === detailedStats.maxWeekdayIndex;
                       const isSelected = selectedWeekday === index;
@@ -1253,7 +1258,8 @@ const StatisticsView = ({
                     className="grid grid-cols-12 gap-1 mb-2"
                   >
                     {detailedStats.hourlyDistribution.map((amount, hour) => {
-                      const maxAmount = Math.max(...detailedStats.hourlyDistribution);
+                      // Bolt: 优化性能，避免使用 ... 带来的中间数组创建和调用栈溢出风险
+                      const maxAmount = detailedStats.hourlyDistribution.reduce((max, val) => Math.max(max, val), -Infinity);
 
                       const heightRatio = maxAmount > 0 ? Math.sqrt(amount / maxAmount) : 0;
                       const height = heightRatio * 80;


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What: Replaced usages of `Math.max(...array)` and `Math.min(...array)` with `.reduce()` logic.
🎯 Why: Using the spread operator with `Math.max/min` can lead to "Maximum call stack size exceeded" errors for large arrays, and using `.map()` beforehand allocates unnecessary intermediate arrays, slowing down performance and increasing memory usage.
📊 Impact: Prevents potential call stack overflow crashes on very large datasets and completely eliminates redundant array allocations for calculating max/min values.
🔬 Measurement: Verify by checking memory profiles and verifying that `Math.max(...` or `Math.min(...` are no longer used on unbounded data loops like records.

---
*PR created automatically by Jules for task [4580474278485370105](https://jules.google.com/task/4580474278485370105) started by @YangguangZhou*