### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-27 - Missing ARIA Labels on Icon-Only Buttons
+**Learning:** Discovered a consistent pattern across multiple components (IntakeForm, ManualImportModal, DrinkSelector, SyncLogModal) where icon-only buttons (like stepper plus/minus controls, modal close 'X' buttons, and action icons like download/copy) were missing aria-label attributes. This severely degrades accessibility for screen reader users as they receive no context about the button's action.
+**Action:** Always verify that every icon-only button includes a descriptive aria-label (e.g., 关闭, 增加容量) when reviewing or building new components in this codebase.

--- a/src/components/DrinkSelector.jsx
+++ b/src/components/DrinkSelector.jsx
@@ -163,6 +163,7 @@ const DrinkSelector = ({
             <button
               onClick={() => setSearchTerm('')}
               className="absolute right-2 top-1/2 transform -translate-y-1/2 p-0.5 rounded-full hover:bg-gray-200 transition-colors"
+              aria-label="清除搜索"
             >
               <X size={12} style={{ color: colors.textMuted }} />
             </button>

--- a/src/components/IntakeForm.jsx
+++ b/src/components/IntakeForm.jsx
@@ -328,6 +328,7 @@ const IntakeForm = ({
               color: colors.textSecondary
             }}
             disabled={!drinkVolume || parseFloat(drinkVolume) <= 0}
+            aria-label="减少容量"
           >
             <Minus size={14} />
           </button>
@@ -369,6 +370,7 @@ const IntakeForm = ({
               backgroundColor: colors.bgBase,
               color: colors.textSecondary
             }}
+            aria-label="增加容量"
           >
             <Plus size={14} />
           </button>
@@ -468,6 +470,7 @@ const IntakeForm = ({
               color: colors.textSecondary
             }}
             disabled={!customAmount || parseFloat(customAmount) <= 0}
+            aria-label="减少剂量"
           >
             <Minus size={14} />
           </button>
@@ -502,6 +505,7 @@ const IntakeForm = ({
               backgroundColor: colors.bgBase,
               color: colors.textSecondary
             }}
+            aria-label="增加剂量"
           >
             <Plus size={14} />
           </button>

--- a/src/components/ManualImportModal.jsx
+++ b/src/components/ManualImportModal.jsx
@@ -161,6 +161,7 @@ const ManualImportModal = ({ onClose, colors, onImportConfig, initialConfigParam
                 onClick={onClose} 
                 className="transition-colors rounded-full p-1"
                 style={{ color: colors.textMuted }}
+                aria-label="关闭"
               >
                 <X size={24} />
               </button>
@@ -238,6 +239,7 @@ const ManualImportModal = ({ onClose, colors, onImportConfig, initialConfigParam
                 onClick={onClose} 
                 className="transition-colors rounded-full p-1"
                 style={{ color: colors.textMuted }}
+                aria-label="关闭"
               >
                 <X size={24} />
               </button>
@@ -299,6 +301,7 @@ const ManualImportModal = ({ onClose, colors, onImportConfig, initialConfigParam
                 onClick={onClose} 
                 className="transition-colors rounded-full p-1"
                 style={{ color: colors.textMuted }}
+                aria-label="关闭"
               >
                 <X size={24} />
               </button>

--- a/src/components/SyncLogModal.jsx
+++ b/src/components/SyncLogModal.jsx
@@ -70,6 +70,7 @@ const SyncLogModal = ({ logs, onClose, colors }) => {
               onClick={handleDownloadLogs}
               className="p-1.5 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
               title="下载/分享日志"
+              aria-label="下载日志"
             >
               <Download size={18} />
             </button>
@@ -77,6 +78,7 @@ const SyncLogModal = ({ logs, onClose, colors }) => {
               onClick={handleCopyLogs}
               className="p-1.5 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
               title="复制日志"
+              aria-label="复制日志"
             >
               <Copy size={18} />
             </button>


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to icon-only buttons

💡 **What:** Added `aria-label` attributes to various icon-only buttons across the application (stepper controls, modal close buttons, action icons).
🎯 **Why:** To improve accessibility for screen reader users by providing clear context for actions where visual icons were the only indicator. 
♿ **Accessibility:** This directly addresses accessibility by ensuring all interactive elements have programmatic labels. Also added a journal entry in `.Jules/palette.md` noting this pattern for future development.

---
*PR created automatically by Jules for task [15150472908137819547](https://jules.google.com/task/15150472908137819547) started by @YangguangZhou*