### PR TITLE
🎨 Palette: Add ARIA labels and focus to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-28 - Missing ARIA Labels on Number Input Buttons
+**Learning:** Custom increment/decrement buttons (`Minus`/`Plus` icons) often lack ARIA labels, making them inaccessible to screen readers. This pattern is common when replacing native number inputs with custom UI controls.
+**Action:** Always verify that custom control buttons, especially icon-only ones, have descriptive `aria-label` and `title` attributes, along with `focus-visible` styles for keyboard navigation.

--- a/src/components/DrinkSelector.jsx
+++ b/src/components/DrinkSelector.jsx
@@ -162,7 +162,10 @@ const DrinkSelector = ({
           {searchTerm && (
             <button
               onClick={() => setSearchTerm('')}
-              className="absolute right-2 top-1/2 transform -translate-y-1/2 p-0.5 rounded-full hover:bg-gray-200 transition-colors"
+              className="absolute right-2 top-1/2 transform -translate-y-1/2 p-0.5 rounded-full hover:bg-gray-200 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+              style={{ '--tw-ring-color': colors.accent + '80' }}
+              aria-label="清除搜索"
+              title="清除搜索"
             >
               <X size={12} style={{ color: colors.textMuted }} />
             </button>

--- a/src/components/IntakeForm.jsx
+++ b/src/components/IntakeForm.jsx
@@ -321,13 +321,16 @@ const IntakeForm = ({
                 setCustomAmount('');
               }
             }}
-            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm"
+            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm focus:outline-none focus-visible:ring-2"
             style={{
               borderColor: colors.borderStrong,
               backgroundColor: colors.bgBase,
-              color: colors.textSecondary
+              color: colors.textSecondary,
+              '--tw-ring-color': colors.accent + '80'
             }}
             disabled={!drinkVolume || parseFloat(drinkVolume) <= 0}
+            aria-label="减少容量"
+            title="减少容量"
           >
             <Minus size={14} />
           </button>
@@ -363,12 +366,15 @@ const IntakeForm = ({
                 setCustomAmount('');
               }
             }}
-            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm"
+            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm focus:outline-none focus-visible:ring-2"
             style={{
               borderColor: colors.borderStrong,
               backgroundColor: colors.bgBase,
-              color: colors.textSecondary
+              color: colors.textSecondary,
+              '--tw-ring-color': colors.accent + '80'
             }}
+            aria-label="增加容量"
+            title="增加容量"
           >
             <Plus size={14} />
           </button>
@@ -461,13 +467,16 @@ const IntakeForm = ({
               const newValue = Math.max(0, current - step);
               setCustomAmount(newValue.toString());
             }}
-            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm"
+            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm focus:outline-none focus-visible:ring-2"
             style={{
               borderColor: colors.borderStrong,
               backgroundColor: colors.bgBase,
-              color: colors.textSecondary
+              color: colors.textSecondary,
+              '--tw-ring-color': colors.accent + '80'
             }}
             disabled={!customAmount || parseFloat(customAmount) <= 0}
+            aria-label="减少摄入量"
+            title="减少摄入量"
           >
             <Minus size={14} />
           </button>
@@ -496,12 +505,15 @@ const IntakeForm = ({
               const newValue = current + step;
               setCustomAmount(newValue.toString());
             }}
-            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm"
+            className="p-1.5 border rounded-md transition-all duration-200 hover:shadow-sm focus:outline-none focus-visible:ring-2"
             style={{
               borderColor: colors.borderStrong,
               backgroundColor: colors.bgBase,
-              color: colors.textSecondary
+              color: colors.textSecondary,
+              '--tw-ring-color': colors.accent + '80'
             }}
+            aria-label="增加摄入量"
+            title="增加摄入量"
           >
             <Plus size={14} />
           </button>


### PR DESCRIPTION
🎨 Palette: Add ARIA labels and focus to icon-only buttons

💡 **What:** Added `aria-label`, `title` tooltips, and `focus-visible` ring styles to the icon-only search clear button (`X`) in `DrinkSelector` and the icon-only increment/decrement adjustment buttons (`Minus`/`Plus`) in `IntakeForm`.
🎯 **Why:** Custom buttons replacing native number inputs often lack accessibility features. Adding these attributes ensures the controls are usable and discoverable for screen reader and keyboard users, preventing them from interacting with "unlabeled buttons".
♿ **Accessibility:** Improved screen reader context (by providing Chinese `aria-label` text) and added visible focus indicators for keyboard navigation.
📸 **Before/After:** Verified visually with Playwright.

Also created a new Palette journal entry in `.Jules/palette.md` to document the critical learning about custom increment/decrement button accessibility patterns in this app.

---
*PR created automatically by Jules for task [9230624998177351637](https://jules.google.com/task/9230624998177351637) started by @YangguangZhou*